### PR TITLE
Update CICD with OIDC config

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,12 +32,8 @@ jobs:
       # manually check it out using a ssh deploy key.
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Get submodules
-        env:
-          SSH_KEY_SUBMODULE: ${{secrets.DELTA_UI_FETCH_KEY}}
-        run: |
-          eval `ssh-agent -s`
-          ssh-add - <<< "${SSH_KEY_SUBMODULE}"; git submodule update --init --recursive
+        with:
+          submodules: recursive
 
       - name: Use Node.js ${{ env.NODE }}
         uses: actions/setup-node@v1
@@ -63,16 +59,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
-      # See comment on checks-yml - prep step
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Get submodules
-        env:
-          SSH_KEY_SUBMODULE: ${{secrets.DELTA_UI_FETCH_KEY}}
-        run: |
-          eval `ssh-agent -s`
-          ssh-add - <<< "${SSH_KEY_SUBMODULE}"; git submodule update --init --recursive
+        with:
+          submodules: recursive
 
       - name: Use Node.js ${{ env.NODE }}
         uses: actions/setup-node@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,6 @@ on:
     branches:
     - main
     - develop
-    - update-cicd
 
 env:
   NODE: 16
@@ -29,8 +28,6 @@ jobs:
             echo "env_name=production" >> $GITHUB_OUTPUT
           elif [ "${{ github.ref }}" = "refs/heads/develop" ]; then
             echo "env_name=staging" >> $GITHUB_OUTPUT
-          elif [ "${{ github.ref }}" = "refs/heads/update-cicd" ]; then
-            echo "env_name=development" >> $GITHUB_OUTPUT
           fi
       - name: Print the environment
         run: echo "The environment is ${{ steps.define_environment.outputs.env_name }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,8 +27,10 @@ jobs:
         run: |
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
             echo "env_name=production" >> $GITHUB_OUTPUT
-          elif [ "${{ github.ref }}" = "refs/heads/update-cicd" ]; then
+          elif [ "${{ github.ref }}" = "refs/heads/develop" ]; then
             echo "env_name=staging" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref }}" = "refs/heads/update-cicd" ]; then
+            echo "env_name=development" >> $GITHUB_OUTPUT
           fi
       - name: Print the environment
         run: echo "The environment is ${{ steps.define_environment.outputs.env_name }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,7 +85,8 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, define-environment]
+    environment: needs.define-environment.outputs.env_name
     steps:
       # See comment on checks.yml - prep step
       - name: Checkout

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -128,7 +128,7 @@ jobs:
         run: |
           aws s3 sync ./dist s3://${{ secrets.S3_BUCKET }}
 
-      # - name: Request Invalidation to AWS Cloudfront
-      #   uses: oneyedev/aws-cloudfront-invalidation@v1
-      #   with:
-      #     distribution-id: ${{ secrets.CF_DISTRIBUTION_ID }}
+      - name: Request Invalidation to AWS Cloudfront
+        uses: oneyedev/aws-cloudfront-invalidation@v1
+        with:
+          distribution-id: ${{ secrets.CF_DISTRIBUTION_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,22 +124,9 @@ jobs:
           role-session-name: "ghgc-dashboard-${{ needs.define-environment.outputs.env_name }}-deployment"
           aws-region: "us-west-2"
 
-      - name: Deploy to S3
-        uses: jakejarvis/s3-sync-action@master
-        with:
-          # acl is not permitted with current credentials
-          # args: --acl public-read --follow-symlinks --delete
-          args: --follow-symlinks --delete
-        env:
-          AWS_S3_BUCKET: ${{ secrets.S3_BUCKET }}
-          AWS_REGION: us-west-2
-          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          # When serving from a subpath:
-          # SOURCE_DIR: ./deploy
-          # Otherwise use the build directory directly:
-          # SOURCE_DIR: ./dist
-          SOURCE_DIR: ./dist
+      - name: Deploy to S3 Production
+        run: |
+          aws s3 sync ./dist s3://${{ secrets.S3_BUCKET }}
 
       # - name: Request Invalidation to AWS Cloudfront
       #   uses: oneyedev/aws-cloudfront-invalidation@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,37 +1,50 @@
 # Deploy the site to AWS S3 on a push to specific branches
 
-name: Deploy Production - MCP (S3)
+name: Deploy
+
+permissions:
+  id-token: write
+  contents: read
 
 on:
   push:
     branches:
-    - 'main'
+    - main
+    - develop
+    - update-cicd
 
 env:
   NODE: 16
-  DOMAIN_PROD: /
-  DEPLOY_BUCKET_PROD: 
-  DEPLOY_BUCKET_PROD_REGION: 
+  DOMAIN: /
 
 jobs:
+  define-environment:
+    name: Set environment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set the environment based on the branch
+        id: define_environment
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "env_name=production" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref }}" = "refs/heads/update-cicd" ]; then
+            echo "env_name=staging" >> $GITHUB_OUTPUT
+          fi
+      - name: Print the environment
+        run: echo "The environment is ${{ steps.define_environment.outputs.env_name }}"
+
+    outputs:
+      env_name: ${{ steps.define_environment.outputs.env_name }}
+
   build:
     runs-on: ubuntu-latest
-
+    needs: define-environment
+    environment: ${{ needs.define-environment.outputs.env_name }}
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.8.0
         with:
           access_token: ${{ github.token }}
-
-      # See comment on checks.yml - prep step
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Get submodules
-        env:
-          SSH_KEY_SUBMODULE: ${{secrets.DELTA_UI_FETCH_KEY}}
-        run: |
-          eval `ssh-agent -s`
-          ssh-add - <<< "${SSH_KEY_SUBMODULE}"; git submodule update --init --recursive
 
       - name: Use Node.js ${{ env.NODE }}
         uses: actions/setup-node@v1
@@ -63,22 +76,18 @@ jobs:
           GOOGLE_TAG_MANAGER_ID: ${{secrets.GOOGLE_TAG_MANAGER_ID}}
           GOOGLE_TAG_AUTH: ${{secrets.GOOGLE_TAG_AUTH}}
           GOOGLE_TAG_PREVIEW: ${{secrets.GOOGLE_TAG_PREVIEW}}
-        run: PUBLIC_URL="${{ env.DOMAIN_PROD }}" yarn build
+        run: PUBLIC_URL="${{ env.DOMAIN }}" yarn build
 
   deploy:
     runs-on: ubuntu-latest
     needs: build
-
     steps:
       # See comment on checks.yml - prep step
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Get submodules
-        env:
-          SSH_KEY_SUBMODULE: ${{secrets.DELTA_UI_FETCH_KEY}}
-        run: |
-          eval `ssh-agent -s`
-          ssh-add - <<< "${SSH_KEY_SUBMODULE}"; git submodule update --init --recursive
+        with:
+          submodules: recursive
+
       - name: Restore node_modules
         uses: actions/cache@v2
         id: cache-node-modules
@@ -100,34 +109,18 @@ jobs:
         with:
           node-version: ${{ env.NODE }}
 
-      - name: Serve site from subpath
-        run: |
-          mkdir deploy/
-          mv dist deploy/dashboard
-          cp deploy/dashboard/index.html deploy/index.html
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.DEPLOYMENT_ROLE_ARN }}
+          role-session-name: "ghgc-dashboard-${{ needs.define-environment.outputs.env_name }}-deployment"
+          aws-region: "us-west-2"
 
       - name: Deploy to S3 Production
-        uses: jakejarvis/s3-sync-action@master
-        with:
-          # acl is not permitted with current credentials
-          # args: --acl public-read --follow-symlinks --delete
-          args: --follow-symlinks --delete
-        env:
-          AWS_S3_BUCKET: ${{ env.DEPLOY_BUCKET_PROD }}
-          AWS_REGION: ${{ env.DEPLOY_BUCKET_PROD_REGION }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          # When serving from a subpath:
-          # SOURCE_DIR: ./deploy
-          # Otherwise use the build directory directly:
-          # SOURCE_DIR: ./dist
-          SOURCE_DIR: ./deploy
+        run: |
+          aws s3 sync ./dist ${{ secrets.S3_BUCKET }}
 
-      - name: Invalidate CloudFront cache
-        uses: chetan/invalidate-cloudfront-action@v2
-        env:
-          DISTRIBUTION: ${{ secrets.CLOUDFRONT_DISTRIBUTION_PROD }}
-          PATHS: "/*"
-          AWS_REGION: ${{ env.DEPLOY_BUCKET_PROD_REGION }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      # - name: Request Invalidation to AWS Cloudfront
+      #   uses: oneyedev/aws-cloudfront-invalidation@v1
+      #   with:
+      #     distribution-id: ${{ secrets.CF_DISTRIBUTION_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,9 +124,22 @@ jobs:
           role-session-name: "ghgc-dashboard-${{ needs.define-environment.outputs.env_name }}-deployment"
           aws-region: "us-west-2"
 
-      - name: Deploy to S3 Production
-        run: |
-          aws s3 sync ./dist ${{ secrets.S3_BUCKET }}
+      - name: Deploy to S3
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          # acl is not permitted with current credentials
+          # args: --acl public-read --follow-symlinks --delete
+          args: --follow-symlinks --delete
+        env:
+          AWS_S3_BUCKET: ${{ secrets.S3_BUCKET }}
+          AWS_REGION: us-west-2
+          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          # When serving from a subpath:
+          # SOURCE_DIR: ./deploy
+          # Otherwise use the build directory directly:
+          # SOURCE_DIR: ./dist
+          SOURCE_DIR: ./dist
 
       # - name: Request Invalidation to AWS Cloudfront
       #   uses: oneyedev/aws-cloudfront-invalidation@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,7 +86,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [build, define-environment]
-    environment: needs.define-environment.outputs.env_name
+    environment: ${{ needs.define-environment.outputs.env_name }}
     steps:
       # See comment on checks.yml - prep step
       - name: Checkout

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Deploy to S3 Production
         run: |
-          aws s3 sync ./dist s3://${{ secrets.S3_BUCKET }}
+          aws s3 sync ./dist s3://${{ secrets.S3_BUCKET }}  --delete
 
       - name: Request Invalidation to AWS Cloudfront
         uses: oneyedev/aws-cloudfront-invalidation@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,11 @@ jobs:
     needs: define-environment
     environment: ${{ needs.define-environment.outputs.env_name }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.8.0
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,6 @@ on:
 
 env:
   NODE: 16
-  DOMAIN: /
 
 jobs:
   define-environment:
@@ -80,7 +79,7 @@ jobs:
           GOOGLE_TAG_MANAGER_ID: ${{secrets.GOOGLE_TAG_MANAGER_ID}}
           GOOGLE_TAG_AUTH: ${{secrets.GOOGLE_TAG_AUTH}}
           GOOGLE_TAG_PREVIEW: ${{secrets.GOOGLE_TAG_PREVIEW}}
-        run: PUBLIC_URL="${{ env.DOMAIN }}" yarn build
+        run: PUBLIC_URL="${{ vars.DOMAIN }}" yarn build
 
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What am I changing and why

- Update CI/CD to use OIDC to connect to Github (better than long-lived keys, same pattern in other GHGC stacks)
- Get rid of subpath for deployment (the dashboard will not be deployed to a subpath)
- Remove Github token (since the repos are already public)
- Set environment based on branch and deploy

## How to test
- I've tested it with the MCP staging environment (frontend accessible yet, I've made a bucket policy change request in MCP); github actions run: https://github.com/NASA-IMPACT/veda-config-ghg/actions/runs/5405447154/jobs/9821343798
- Should automatically deploy to staging (future url: staging.ghg.center) on merge to develop
