### PR TITLE
Change stories name to Data Insights

### DIFF
--- a/veda.config.js
+++ b/veda.config.js
@@ -30,8 +30,8 @@ module.exports = {
 
   strings: {
     stories: {
-      one: ' Data Story',
-      other: 'Data Stories'
+      one: 'Data Insights',
+      other: 'Data Insights'
     }
   },
 


### PR DESCRIPTION
Closes https://github.com/NASA-IMPACT/veda-config-ghg/issues/68

NB: I used "Data Insights" also for singular.

The singular version gets used e.g. in the list of "Featured Data Insights", if we ever create one:

![image](https://github.com/NASA-IMPACT/veda-config/assets/3404817/9a95326b-8901-40c4-bdae-fe4b5ead2178)

"Data Insights", unlike "Story", does not describe the item but the content, I guess. But let's see how this works.