### PR TITLE
Update emit dataset to point to lpdaac version

### DIFF
--- a/datasets/emit-plume.data.mdx
+++ b/datasets/emit-plume.data.mdx
@@ -35,7 +35,7 @@ taxonomy:
       - Satellite Data
 layers:
   - id: ch4-plume-emissions
-    stacCol: emit-ch4plume-v1
+    stacCol: emit-ch4plume-v1-lpdaac
     name: CH4 point source plume complexes
     type: raster
     description: Methane point source plume complex extents with methane enhancements


### PR DESCRIPTION
# Description
Update EMIT dataset to point to the lpdaac version collection.

This is a temporary change, for migration.

We're going to update the actual collection id `emit-ch4plume-v1` with the lpdaac version and revert the change.