### PR TITLE
Update hero image alt text and caption

### DIFF
--- a/overrides/components/home-hero/component.tsx
+++ b/overrides/components/home-hero/component.tsx
@@ -99,12 +99,12 @@ export default function HomeHero(props) {
         ) : (
           <img
             src={coverImgSrc}
-            alt="Image of northern hemisphere of earth with gas in atmosphere shown in red hues"
+            alt="visualizaion of january 2021 global atmospheric carbon dioxide"
           />
         )}
         <Figcaption>
           <FigureAttribution
-            author="Helen-Nicole Kostis, Lead Visualizer, Scientific Visualization Studio. Image of January 2021 Global Atmospheric Carbon Dioxide (CO₂)"
+            author="NASA's Scientific Visualization Studio. Visualization of January 2021 Global Atmospheric Carbon Dioxide (CO₂)"
             url="https://svs.gsfc.nasa.gov/5115"
             position="bottom-right"
           />


### PR DESCRIPTION
Changes hero image alt text and caption to correctly name the source unit and refer to "visualization" rather than "image" (will be animation on desktop and image on mobile).

It will still say "Figure by", since that is common to all captions. We can change that globally later, if we want.

Closes https://github.com/NASA-IMPACT/veda-config-ghg/issues/145