### PR TITLE
Update default metrics on selected datasets 

### DIFF
--- a/datasets/casagfed-carbonflux-monthgrid-v3.data.mdx
+++ b/datasets/casagfed-carbonflux-monthgrid-v3.data.mdx
@@ -76,6 +76,9 @@ layers:
         - '#C10E51'
         - '#92003F'
         - '#67001F'
+    analysis:
+      metrics:
+        - mean
   - id: casa-gfed-co2-flux-hr
     stacCol: casagfed-carbonflux-monthgrid-v3
     name: Heterotrophic Respiration (Rh)
@@ -118,6 +121,9 @@ layers:
         - '#C10E51'
         - '#92003F'
         - '#67001F'
+    analysis:
+      metrics:
+        - mean
   - id: casa-gfed-co2-flux-nee
     stacCol: casagfed-carbonflux-monthgrid-v3
     name: Net Ecosystem Exchange (NEE)
@@ -158,6 +164,9 @@ layers:
         - '#F7A889'
         - '#E26952'
         - '#B40426'
+    analysis:
+      metrics:
+        - mean
   - id: casa-gfed-co2-flux-fe
     stacCol: casagfed-carbonflux-monthgrid-v3
     name: Fire Emissions (FIRE)
@@ -200,6 +209,9 @@ layers:
         - '#C10E51'
         - '#92003F'
         - '#67001F'
+    analysis:
+      metrics:
+        - mean
   - id: casa-gfed-co2-flux-fuel
     stacCol: casagfed-carbonflux-monthgrid-v3
     name: Wood Fuel Emissions (FUEL)
@@ -240,6 +252,9 @@ layers:
         - '#894DA3'
         - '#821580'
         - '#4D004B'
+    analysis:
+      metrics:
+        - mean
 ---
 
 <Block type='wide'>

--- a/datasets/eccodarwin-co2flux-monthgrid-v5.data.mdx
+++ b/datasets/eccodarwin-co2flux-monthgrid-v5.data.mdx
@@ -74,6 +74,9 @@ layers:
         - "#FF66CC"
         - "#FF3399"
         - "#FF0000"
+    analysis:
+      metrics:
+        - mean
 ---
 
 <Block type='wide'>


### PR DESCRIPTION
For most datasets, there is a sensible default for which zonal statistics to show on time series plots (results of analysis).

This is to configure some of them, for illustration / testing.