### PR TITLE
Fix broken external link to gas flaring photo

### DIFF
--- a/stories/us-methane-sources.stories.mdx
+++ b/stories/us-methane-sources.stories.mdx
@@ -54,7 +54,7 @@ taxonomy:
                 alt="colorful gas flare from chimney against blue sky"
                 align="left"
                 attrAuthor="Leslie Von Pless"
-                attrUrl="https://www.nasa.gov/sites/default/files/thumbnails/image/1-permian-methane-von-pless-gas-flaring-photo-hi-rez-1041.jpg"
+                attrUrl="https://www.nasa.gov/wp-content/uploads/2021/06/1-permian-methane-von-pless-gas-flaring-photo-hi-rez-1041.jpg"
             />
             <Caption> Gas flaring during oil and gas production is a known source of methane emissions </Caption>
         </Figure>


### PR DESCRIPTION
Perhaps in the context of the new NASA website launch, this link broke. @amarouane-ABDELHAK's link checker detected it.