### PR TITLE
Update banner to summer school info (Bypassing staging)

### DIFF
--- a/overrides/home/ams-banner.tsx
+++ b/overrides/home/ams-banner.tsx
@@ -10,7 +10,7 @@ import {
 import Hug from "$veda-ui-scripts/styles/hug";
 import { getString } from 'veda';
 
-const AMS_BANNER_KEY = 'show-ams-banner'
+const AMS_BANNER_KEY = 'show-summer-school-banner'
 
 const BannerBox = styled.div`
   position: absolute;

--- a/overrides/home/banner.tsx
+++ b/overrides/home/banner.tsx
@@ -10,7 +10,7 @@ import {
 import Hug from "$veda-ui-scripts/styles/hug";
 import { getString } from 'veda';
 
-const AMS_BANNER_KEY = 'show-summer-school-banner'
+const BANNER_KEY = 'dismissedBannerUrl'
 
 const BannerBox = styled.div`
   position: absolute;
@@ -53,13 +53,14 @@ const BannerContent = styled.div`
 `
 
 export default function Banner() {
-  const showBanner = (localStorage.getItem(AMS_BANNER_KEY) !== 'false') && !!getString('tempBanner')?.other
+  const bannerUrl = getString('tempBannerUrl')?.other || "";
+  const showBanner = (localStorage.getItem(BANNER_KEY) !== bannerUrl) && !!getString('tempBanner')?.other
   const [ showTempBanner, setShowTempBanner ] = useState(showBanner);
 
   function onClick () {
     localStorage.setItem(
-      AMS_BANNER_KEY,
-      'false'
+      BANNER_KEY,
+      bannerUrl
     );
     setShowTempBanner(false);
   }

--- a/overrides/home/component.tsx
+++ b/overrides/home/component.tsx
@@ -11,7 +11,7 @@ import { variableGlsp } from "$veda-ui-scripts/styles/variable-utils";
 import Partners from "./partners";
 import Keypoints from "./keypoints";
 import { ArrowLink } from "./arrow-link";
-import AMSBanner from './ams-banner';
+import Banner from './banner';
 
 const HomeContent = styled(Hug)`
   padding: ${variableGlsp(2.5, 0)};
@@ -89,7 +89,7 @@ const InfoCalloutHeadline = styled.div`
 export default function HomeComponent() {
   return (
     <>
-    <AMSBanner />
+    <Banner />
       <HomeContent>
         <IntroHeadline>
           <VarHeading size="xxlarge">Welcome</VarHeading>

--- a/veda.config.js
+++ b/veda.config.js
@@ -42,9 +42,9 @@ module.exports = {
         "This dashboard is for exploring key datasets that provide insight into greenhouse gas sources, sinks, emissions, fluxes, and events.",
     // Temporary Banner Text/URL
     tempBanner:
-        "Attending AMS Annual Meeting in Baltimore?  Join the GHG Center / VEDA workshop and learn about Greenhouse Gases using Open Source data and tools. Register Here!",
+        "Graduate students and early career post-docs are invited to apply for the Summer School for Inverse Modeling of Greenhouse Gases to be held June 11-21, 2024 in Fort Collins, CO. Applications due 1/31/2024.",
     tempBannerUrl:
-        "https://www.ametsoc.org/index.cfm/ams/education-careers/careers/professional-development/short-courses/advancing-open-science-an-interactive-workshop-on-harnessing-veda-for-earth-science-research-at-the-u-s-greenhouse-gas-center/"
+        "https://www.cira.colostate.edu/conferences/rmtgw/"
   },
 
   theme: {


### PR DESCRIPTION
# Changes
- Generalized banner (removed mention of "AMS")
- Used banner URL in localStorage to identify if the banner has been dismissed (so we don't have to change the key each time)
- Changed banner text/url to have summer school info