### PR TITLE
Disable S3 Cache during the deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Deploy to S3 Production
         run: |
-          aws s3 sync ./dist s3://${{ secrets.S3_BUCKET }}${{ vars.SUBPATH }} --cache-control max-age=604800,must-revalidate,s-maxage=604800 --delete
+          aws s3 sync ./dist s3://${{ secrets.S3_BUCKET }}${{ vars.SUBPATH }} --cache-control max-age=30,must-revalidate,s-maxage=60 --delete
       - name: Request Invalidation to AWS Cloudfront
         uses: oneyedev/aws-cloudfront-invalidation@v1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Deploy to S3 Production
         run: |
-          aws s3 sync ./dist s3://${{ secrets.S3_BUCKET }}${{ vars.SUBPATH }} --cache-control max-age=30,must-revalidate,s-maxage=60 --delete
+          aws s3 sync ./dist s3://${{ secrets.S3_BUCKET }}${{ vars.SUBPATH }} --cache-control max-age=30,must-revalidate,s-maxage=604800 --delete
       - name: Request Invalidation to AWS Cloudfront
         uses: oneyedev/aws-cloudfront-invalidation@v1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Deploy to S3 Production
         run: |
-          aws s3 sync ./dist s3://${{ secrets.S3_BUCKET }}${{ vars.SUBPATH }} --cache-control max-age=604800 --delete 
+          aws s3 sync ./dist s3://${{ secrets.S3_BUCKET }}${{ vars.SUBPATH }} --cache-control no-cache,no-store --delete 
 
       - name: Request Invalidation to AWS Cloudfront
         uses: oneyedev/aws-cloudfront-invalidation@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,8 +122,7 @@ jobs:
 
       - name: Deploy to S3 Production
         run: |
-          aws s3 sync ./dist s3://${{ secrets.S3_BUCKET }}${{ vars.SUBPATH }} --cache-control no-cache,no-store --delete 
-
+          aws s3 sync ./dist s3://${{ secrets.S3_BUCKET }}${{ vars.SUBPATH }} --cache-control max-age=604800,must-revalidate,s-maxage=604800 --delete
       - name: Request Invalidation to AWS Cloudfront
         uses: oneyedev/aws-cloudfront-invalidation@v1
         with:


### PR DESCRIPTION
<!-- -----------^ Click "Preview" for a functional view! -->

## Why are you creating this Pull Request?

We are disabling S3 caching to force the web application to fetch the latest assets from S3 (we still need to ensure there is no caching in the cloudfront side)
Pros:
- Every page refresh will guaranty the web application is retrieving the latest assets version 
- There is no impact on the performance if the user did not explicitly refresh the page

Cons:
- A potential of increase the latency since hot-cache and store cache are disabled 
- Every call will request the file from S3 so we will experience an addition cost (probably minimal)
