### PR TITLE
Fix: missing datasets in data-catalog

### DIFF
--- a/datasets/emit-ch4plume-v1.data.mdx
+++ b/datasets/emit-ch4plume-v1.data.mdx
@@ -33,7 +33,7 @@ taxonomy:
   - name: Product Type
     values:
       - Satellite Observations
-disableExplore: true     
+disableExplore: false     
 layers:
   - id: ch4-plume-emissions
     stacCol: emit-ch4plume-v1

--- a/datasets/noaa-cpfp-ch4-point.data.mdx
+++ b/datasets/noaa-cpfp-ch4-point.data.mdx
@@ -20,7 +20,7 @@ taxonomy:
   - name: Gas
     values:
       - CH₄
-disableExplore: true
+disableExplore: false
 layers:
   - id: noaa-cpfp-ch4-point
     stacCol: noaa-cpfp-ch4-point

--- a/datasets/noaa-cpfp-co2-point.data.mdx
+++ b/datasets/noaa-cpfp-co2-point.data.mdx
@@ -20,7 +20,7 @@ taxonomy:
   - name: Gas
     values:
       - CO₂
-disableExplore: true
+disableExplore: false
 layers:
   - id: noaa-cpfp-co2-point
     stacCol: noaa-cpfp-co2-point

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "veda-config",
   "description": "Configuration for Veda",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "source": "./.veda/ui/app/index.html",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
## What am I changing and why

The `disableExplore` flag in noaa and emit datasets caused them to not appear in the data catalog. This was possibly because of a newer change that sneaked in through veda-ui update.

Setting them to `false` for now, while we fix the logic later.
