### PR TITLE
Release v1.0.5

### DIFF
--- a/datasets/emit-ch4plume-v1.data.mdx
+++ b/datasets/emit-ch4plume-v1.data.mdx
@@ -33,7 +33,7 @@ taxonomy:
   - name: Product Type
     values:
       - Satellite Observations
-disableExplore: false     
+disableExplore: true
 layers:
   - id: ch4-plume-emissions
     stacCol: emit-ch4plume-v1

--- a/datasets/emit-ch4plume-v1.data.mdx
+++ b/datasets/emit-ch4plume-v1.data.mdx
@@ -33,7 +33,7 @@ taxonomy:
   - name: Product Type
     values:
       - Satellite Observations
-disableExplore: true     
+disableExplore: false     
 layers:
   - id: ch4-plume-emissions
     stacCol: emit-ch4plume-v1

--- a/datasets/noaa-cpfp-ch4-point.data.mdx
+++ b/datasets/noaa-cpfp-ch4-point.data.mdx
@@ -20,7 +20,7 @@ taxonomy:
   - name: Gas
     values:
       - CH₄
-disableExplore: false
+disableExplore: true
 layers:
   - id: noaa-cpfp-ch4-point
     stacCol: noaa-cpfp-ch4-point

--- a/datasets/noaa-cpfp-ch4-point.data.mdx
+++ b/datasets/noaa-cpfp-ch4-point.data.mdx
@@ -20,7 +20,7 @@ taxonomy:
   - name: Gas
     values:
       - CH₄
-disableExplore: true
+disableExplore: false
 layers:
   - id: noaa-cpfp-ch4-point
     stacCol: noaa-cpfp-ch4-point

--- a/datasets/noaa-cpfp-co2-point.data.mdx
+++ b/datasets/noaa-cpfp-co2-point.data.mdx
@@ -20,7 +20,7 @@ taxonomy:
   - name: Gas
     values:
       - CO₂
-disableExplore: false
+disableExplore: true
 layers:
   - id: noaa-cpfp-co2-point
     stacCol: noaa-cpfp-co2-point

--- a/datasets/noaa-cpfp-co2-point.data.mdx
+++ b/datasets/noaa-cpfp-co2-point.data.mdx
@@ -20,7 +20,7 @@ taxonomy:
   - name: Gas
     values:
       - CO₂
-disableExplore: true
+disableExplore: false
 layers:
   - id: noaa-cpfp-co2-point
     stacCol: noaa-cpfp-co2-point

--- a/overrides/components/page-footer/component.tsx
+++ b/overrides/components/page-footer/component.tsx
@@ -27,7 +27,9 @@ import { useMediaQuery } from "$veda-ui-scripts/utils/use-media-query";
 import Partners from "../../home/partners";
 import { AccessibilityMenuItem } from "../../common/styles";
 
+
 const PRESS_PATH = '/learn#press';
+
 
 const FooterInner = styled.div`
   display: flex;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "veda-config",
   "description": "Configuration for Veda",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "source": "./.veda/ui/app/index.html",
   "license": "Apache-2.0",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "veda-config",
   "description": "Configuration for Veda",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "source": "./.veda/ui/app/index.html",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
_The PR name should be the version to be deployed (ex: v1.0.1)_

- [x] Bump the version in the package.json or equivalent.

---

# Changelog v1.0.5
-  This release includes veda-ui 4.1.0. You can read VEDA UI 4.1.0 release in [the release note](https://github.com/NASA-IMPACT/veda-ui/releases/tag/v4.1.0)

